### PR TITLE
Adding support for custom endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .pytest_cache
 tests/projects
 htmlcov
+*.pyc
+__pycache__/

--- a/lazydata/cli/commands/addremote.py
+++ b/lazydata/cli/commands/addremote.py
@@ -12,10 +12,12 @@ class AddRemoteCommand(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('url', type=str, help='URL of the remote storage backend')
+        parser.add_argument('--endpoint-url', type=str, nargs='?', help='The complete URL to use for the constructed client')
         return parser
 
     def handle(self, args):
         url = args.url
+        endpoint_url = args.endpoint_url
 
         if not url.startswith("s3://"):
             print("ERROR: Only S3 URLs are currently supported. For example: `s3://mybucket` or `s3://mybucket/myfolder`")
@@ -23,11 +25,11 @@ class AddRemoteCommand(BaseCommand):
 
         success = False
         while not success:
-            remote = RemoteStorage.get_from_url(url)
+            remote = RemoteStorage.get_from_url(url, endpoint_url=endpoint_url)
             try:
                 if remote.check_storage_exists():
                     config = Config()
-                    config.add_remote(url)
+                    config.add_remote(url, endpoint_url=endpoint_url)
                     success = True
                 else:
                     success = True

--- a/lazydata/config/config.py
+++ b/lazydata/config/config.py
@@ -122,7 +122,7 @@ class Config:
 
         self.save_config()
 
-    def add_remote(self, remote_url:str):
+    def add_remote(self, remote_url:str, endpoint_url:str):
         """
         Add a remote to the config file
 
@@ -133,7 +133,9 @@ class Config:
         if "remote" in self.config:
             print("ERROR: Remote storage backend in `lazydata.yml` already exists. Aborting...")
         else:
+            # Setting the remote config automatically sets the endpoint parameter, even if it is None
             self.config["remote"] = remote_url
+            self.config["endpoint"] = endpoint_url
             self.save_config()
 
     def check_file_tracked(self, path:str):
@@ -181,6 +183,8 @@ class Config:
             yaml.dump({"version": self.config["version"]}, fp, default_flow_style=False)
             if "remote" in self.config:
                 yaml.dump({"remote": self.config["remote"]}, fp, default_flow_style=False)
+            if "endpoint" in self.config:
+                yaml.dump({"endpoint": self.config["endpoint"]}, fp, default_flow_style=False)
             if "files" in self.config:
                 yaml.dump({"files": self.config["files"]}, fp, default_flow_style=False)
 

--- a/lazydata/storage/local.py
+++ b/lazydata/storage/local.py
@@ -98,7 +98,7 @@ class LocalStorage:
         if not datapath.exists():
             # Hard-link the file to the path
             datapath.parent.mkdir(parents=True, exist_ok=True)
-            os.link(abspath, str(datapath))
+            os.link(str(abspath), str(datapath))
 
         # Store in the metadata DB if doesn't exist already
         existing_entries = DataFile.select().where(

--- a/lazydata/storage/remote.py
+++ b/lazydata/storage/remote.py
@@ -25,16 +25,16 @@ class RemoteStorage:
     """
 
     @staticmethod
-    def get_from_url(remote_url:str):
+    def get_from_url(remote_url:str, endpoint_url:str):
         if remote_url.startswith("s3://"):
-            return AWSRemoteStorage(remote_url)
+            return AWSRemoteStorage(remote_url, endpoint_url=endpoint_url)
         else:
             raise RuntimeError("Url `%s` is not supported as a remote storage backend" % remote_url)
 
     @staticmethod
     def get_from_config(config:Config):
         if "remote" in config.config:
-            return RemoteStorage.get_from_url(config.config["remote"])
+            return RemoteStorage.get_from_url(config.config["remote"], config.config["endpoint"])
         else:
             raise RuntimeError("Remote storage backend not configured for this lazydata project.")
 
@@ -72,7 +72,7 @@ class RemoteStorage:
 
 class AWSRemoteStorage(RemoteStorage):
 
-    def __init__(self, remote_url):
+    def __init__(self, remote_url, endpoint_url=None):
         if not remote_url.startswith("s3://"):
             raise RuntimeError("AWSRemoteStorage URL needs to start with s3://")
 
@@ -84,8 +84,8 @@ class AWSRemoteStorage(RemoteStorage):
         if self.path_prefix.startswith("/"):
             self.path_prefix = self.path_prefix[1:]
         # get the reusable clients and resources
-        self.s3 = boto3.resource('s3')
-        self.client = boto3.client('s3')
+        self.s3 = boto3.resource('s3', endpoint_url=endpoint_url)
+        self.client = boto3.client('s3', endpoint_url=endpoint_url)
 
     def check_storage_exists(self):
         exists = True


### PR DESCRIPTION
Useful for users that do not want to rely on Amazon S3 while using this package.

I'm running a [Minio Server](https://github.com/minio/minio) for storage, which mimics an S3 container.

boto3 ([api doc here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)) supports custom endpoints that it's going to hit via the S3 API.

I would be good to add tests to this behaviour, along with testing pulls and pushes for normal behaviour. Using mocks maybe ?

EDIT: I also corrected a line which caused the package not to work for python 3.5, see commit 
0d4f8fc 